### PR TITLE
run.js should set development: false

### DIFF
--- a/bin/run.js
+++ b/bin/run.js
@@ -3,5 +3,5 @@
 // eslint-disable-next-line unicorn/prefer-top-level-await
 (async () => {
   const oclif = await import('@oclif/core')
-  await oclif.execute({development: true, dir: __dirname})
+  await oclif.execute({development: false, dir: __dirname})
 })()


### PR DESCRIPTION
I assume this bug was introduced recently as part of supporting ESM and CJS packages.