### PR TITLE
chore: add `oclif.lock` to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,6 @@
 /tmp
 node_modules
 oclif.manifest.json
+oclif.lock
 **/.DS_Store
 /.idea


### PR DESCRIPTION
ignore `oclif.lock`, it's not supposed to be committed into the repo.