### PR TITLE
fix: use local ts node

### DIFF
--- a/bin/dev.js
+++ b/bin/dev.js
@@ -1,6 +1,6 @@
-#!/usr/bin/env ts-node
+#!/usr/bin/env node_modules/.bin/ts-node
 // eslint-disable-next-line node/shebang, unicorn/prefer-top-level-await
-(async () => {
+;(async () => {
   const oclif = await import('@oclif/core')
   await oclif.execute({development: true, dir: __dirname})
 })()

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "bugs": "https://github.com/oclif/hello-world/issues",
   "dependencies": {
     "@oclif/core": "^3",
-    "@oclif/plugin-help": "^5",
+    "@oclif/plugin-help": "^6",
     "@oclif/plugin-plugins": "^4"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -505,7 +505,7 @@
     wordwrap "^1.0.0"
     wrap-ansi "^7.0.0"
 
-"@oclif/core@^3", "@oclif/core@^3.10.2", "@oclif/core@^3.10.8":
+"@oclif/core@^3", "@oclif/core@^3.10.2", "@oclif/core@^3.10.8", "@oclif/core@^3.11.0":
   version "3.12.0"
   resolved "https://registry.yarnpkg.com/@oclif/core/-/core-3.12.0.tgz#4b38b1b5dab2f7585f89c3927a8a157b258b4bd6"
   integrity sha512-mT1Vpd1E20IJ7P6GDYOivylPdTHq/xVgFjeCDjitFW86UAklFM8BEFyFB7KpsTvpmjRbCoda3yU10lSI1224lw==
@@ -538,12 +538,19 @@
     wordwrap "^1.0.0"
     wrap-ansi "^7.0.0"
 
-"@oclif/plugin-help@^5", "@oclif/plugin-help@^5.2.14":
+"@oclif/plugin-help@^5.2.14":
   version "5.2.20"
   resolved "https://registry.yarnpkg.com/@oclif/plugin-help/-/plugin-help-5.2.20.tgz#4035a0ac231f95fb8e334da342175e3ca00f6abc"
   integrity sha512-u+GXX/KAGL9S10LxAwNUaWdzbEBARJ92ogmM7g3gDVud2HioCmvWQCDohNRVZ9GYV9oKwZ/M8xwd6a1d95rEKQ==
   dependencies:
     "@oclif/core" "^2.15.0"
+
+"@oclif/plugin-help@^6":
+  version "6.0.7"
+  resolved "https://registry.yarnpkg.com/@oclif/plugin-help/-/plugin-help-6.0.7.tgz#0bad86335dbf687d0ba03c98f5e541109f9ac371"
+  integrity sha512-+apYpLuNk6VGNuZZbFdwUlTcFb+FkQnySWR5S5pZYC+yHcT39zgOK06NAheHHhd5KSzroFwQu7RTdHnK6Tzakg==
+  dependencies:
+    "@oclif/core" "^3.11.0"
 
 "@oclif/plugin-not-found@^2.3.32":
   version "2.3.32"


### PR DESCRIPTION
Use local `ts-node` executable in node_modules instead of assuming a globally available ts-node. See https://github.com/oclif/oclif/issues/1211